### PR TITLE
fix: Peer dependency version

### DIFF
--- a/.changeset/busy-tables-tan.md
+++ b/.changeset/busy-tables-tan.md
@@ -1,0 +1,5 @@
+---
+"@namesake/tiptap-extensions": patch
+---
+
+Fix peer dependency for Tiptap

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@tiptap/core": "^2.11.9"
+    "@tiptap/core": "^3.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Specify peer dependency of `@tiptap/core@3.0.1`.